### PR TITLE
Implement core registrar API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
-group = 'ph.edu.cspb'
+group = 'ph.edu.cspb.registrar'
 version = '0.0.1-SNAPSHOT'
 
 java {
@@ -20,23 +20,34 @@ configurations {
 }
 
 repositories {
-	mavenCentral()
+        mavenCentral()
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.testcontainers:testcontainers-bom:1.19.8"
+    }
 }
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.flywaydb:flyway-core'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-database-postgresql'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'org.postgresql:postgresql'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    compileOnly 'org.projectlombok:lombok:1.18.32'
+    compileOnly 'org.mapstruct:mapstruct:1.6.3.Final'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    runtimeOnly 'org.postgresql:postgresql'
+    annotationProcessor 'org.projectlombok:lombok:1.18.32'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3.Final'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.testcontainers:postgresql'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
-// tasks.named('test') {
-// 	useJUnitPlatform()
-// }
+tasks.named("test") {
+    useJUnitPlatform()
+}

--- a/src/main/java/ph/edu/cspb/registrar/api/StudentController.java
+++ b/src/main/java/ph/edu/cspb/registrar/api/StudentController.java
@@ -1,0 +1,211 @@
+package ph.edu.cspb.registrar.api;
+
+import ph.edu.cspb.registrar.dto.*;
+import ph.edu.cspb.registrar.mapper.*;
+import ph.edu.cspb.registrar.model.*;
+import ph.edu.cspb.registrar.repo.*;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api")
+public class StudentController {
+
+    private final StudentRepository studentRepository;
+    private final AddressRepository addressRepository;
+    private final RequirementTypeRepository requirementTypeRepository;
+    private final RequirementRepository requirementRepository;
+    private final StudentMapper studentMapper;
+    private final AddressMapper addressMapper;
+    private final RequirementTypeMapper requirementTypeMapper;
+    private final RequirementMapper requirementMapper;
+
+    public StudentController(StudentRepository studentRepository,
+                             AddressRepository addressRepository,
+                             RequirementTypeRepository requirementTypeRepository,
+                             RequirementRepository requirementRepository,
+                             StudentMapper studentMapper,
+                             AddressMapper addressMapper,
+                             RequirementTypeMapper requirementTypeMapper,
+                             RequirementMapper requirementMapper) {
+        this.studentRepository = studentRepository;
+        this.addressRepository = addressRepository;
+        this.requirementTypeRepository = requirementTypeRepository;
+        this.requirementRepository = requirementRepository;
+        this.studentMapper = studentMapper;
+        this.addressMapper = addressMapper;
+        this.requirementTypeMapper = requirementTypeMapper;
+        this.requirementMapper = requirementMapper;
+    }
+
+    @GetMapping("/students")
+    public Page<StudentDto> listStudents(@RequestParam(required = false) String lastName,
+                                         Pageable pageable) {
+        Page<Student> page = (lastName == null)
+                ? studentRepository.findAll(pageable)
+                : studentRepository.findByLastNameContainingIgnoreCase(lastName, pageable);
+        return page.map(studentMapper::toDto);
+    }
+
+    @GetMapping("/students/{id}")
+    public ResponseEntity<StudentDto> getStudent(@PathVariable Long id) {
+        return studentRepository.findById(id)
+                .map(studentMapper::toDto)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping("/students")
+    public ResponseEntity<StudentDto> createStudent(@Valid @RequestBody StudentDto dto) {
+        Student saved = studentRepository.save(studentMapper.toEntity(dto));
+        return ResponseEntity.ok(studentMapper.toDto(saved));
+    }
+
+    @PutMapping("/students/{id}")
+    public ResponseEntity<StudentDto> updateStudent(@PathVariable Long id,
+                                                    @Valid @RequestBody StudentDto dto) {
+        return studentRepository.findById(id)
+                .map(existing -> {
+                    Student entity = studentMapper.toEntity(dto);
+                    entity.setId(id);
+                    entity.setAddress(existing.getAddress());
+                    entity.setRequirements(existing.getRequirements());
+                    Student saved = studentRepository.save(entity);
+                    return ResponseEntity.ok(studentMapper.toDto(saved));
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PatchMapping("/students/{id}")
+    public ResponseEntity<StudentDto> patchStudent(@PathVariable Long id,
+                                                   @RequestBody StudentDto dto) {
+        return studentRepository.findById(id)
+                .map(existing -> {
+                    Student entity = studentMapper.toEntity(dto);
+                    if (dto.lrn() != null) existing.setLrn(dto.lrn());
+                    if (dto.lastName() != null) existing.setLastName(dto.lastName());
+                    if (dto.firstName() != null) existing.setFirstName(dto.firstName());
+                    if (dto.middleName() != null) existing.setMiddleName(dto.middleName());
+                    if (dto.extensionName() != null) existing.setExtensionName(dto.extensionName());
+                    if (dto.birthDate() != null) existing.setBirthDate(dto.birthDate());
+                    if (dto.birthPlace() != null) existing.setBirthPlace(dto.birthPlace());
+                    if (dto.gender() != null) existing.setGender(dto.gender());
+                    if (dto.nationality() != null) existing.setNationality(dto.nationality());
+                    if (dto.religion() != null) existing.setReligion(dto.religion());
+                    if (dto.numSiblings() != null) existing.setNumSiblings(dto.numSiblings());
+                    if (dto.siblingNames() != null) existing.setSiblingNames(dto.siblingNames());
+                    if (dto.imgPath() != null) existing.setImgPath(dto.imgPath());
+                    Student saved = studentRepository.save(existing);
+                    return ResponseEntity.ok(studentMapper.toDto(saved));
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/students/{id}")
+    public ResponseEntity<Void> deleteStudent(@PathVariable Long id) {
+        if (studentRepository.existsById(id)) {
+            studentRepository.deleteById(id);
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.notFound().build();
+    }
+
+    @GetMapping("/students/{id}/address")
+    public ResponseEntity<AddressDto> getAddress(@PathVariable Long id) {
+        return addressRepository.findById(id)
+                .map(addressMapper::toDto)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/students/{id}/address")
+    public ResponseEntity<AddressDto> putAddress(@PathVariable Long id,
+                                                 @Valid @RequestBody AddressDto dto) {
+        return studentRepository.findById(id)
+                .map(student -> {
+                    Address address = addressRepository.findById(id).orElse(new Address());
+                    Address entity = addressMapper.toEntity(dto);
+                    entity.setStudent(student);
+                    entity.setStudentId(id);
+                    entity.setCreatedAt(address.getCreatedAt());
+                    Address saved = addressRepository.save(entity);
+                    return ResponseEntity.ok(addressMapper.toDto(saved));
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/students/{id}/address")
+    public ResponseEntity<Void> deleteAddress(@PathVariable Long id) {
+        if (addressRepository.existsById(id)) {
+            addressRepository.deleteById(id);
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.notFound().build();
+    }
+
+    @GetMapping("/requirement-types")
+    public List<RequirementTypeDto> getRequirementTypes() {
+        return requirementTypeRepository.findAll().stream()
+                .map(requirementTypeMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @GetMapping("/students/{id}/requirements")
+    public ResponseEntity<List<RequirementDto>> getRequirements(@PathVariable Long id) {
+        return studentRepository.findById(id)
+                .map(student -> requirementRepository.findAll().stream()
+                        .filter(r -> r.getStudent().getId().equals(id))
+                        .map(requirementMapper::toDto)
+                        .collect(Collectors.toList()))
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/students/{id}/requirements/{typeId}")
+    public ResponseEntity<Void> putRequirement(@PathVariable Long id,
+                                               @PathVariable Short typeId,
+                                               @RequestBody RequirementDto dto) {
+        Optional<Student> studentOpt = studentRepository.findById(id);
+        Optional<RequirementType> typeOpt = requirementTypeRepository.findById(typeId);
+        if (studentOpt.isEmpty() || typeOpt.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        RequirementId rid = new RequirementId(id, typeId);
+        Requirement req = requirementRepository.findById(rid).orElse(new Requirement());
+        req.setId(rid);
+        req.setStudent(studentOpt.get());
+        req.setRequirementType(typeOpt.get());
+        req.setSubmitted(dto.submitted());
+        req.setSubmittedDate(dto.submittedDate());
+        requirementRepository.save(req);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/students/{id}/requirements")
+    public ResponseEntity<Void> patchRequirements(@PathVariable Long id,
+                                                  @RequestBody List<RequirementDto> list) {
+        Optional<Student> studentOpt = studentRepository.findById(id);
+        if (studentOpt.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        for (RequirementDto dto : list) {
+            RequirementId rid = new RequirementId(id, dto.requirementTypeId());
+            Requirement req = requirementRepository.findById(rid).orElse(new Requirement());
+            req.setId(rid);
+            req.setStudent(studentOpt.get());
+            requirementTypeRepository.findById(dto.requirementTypeId())
+                    .ifPresent(req::setRequirementType);
+            req.setSubmitted(dto.submitted());
+            req.setSubmittedDate(dto.submittedDate());
+            requirementRepository.save(req);
+        }
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/ph/edu/cspb/registrar/dto/AddressDto.java
+++ b/src/main/java/ph/edu/cspb/registrar/dto/AddressDto.java
@@ -1,0 +1,8 @@
+package ph.edu.cspb.registrar.dto;
+
+public record AddressDto(
+        String houseNo,
+        String streetSubd,
+        String bgyCode
+) {
+}

--- a/src/main/java/ph/edu/cspb/registrar/dto/RequirementDto.java
+++ b/src/main/java/ph/edu/cspb/registrar/dto/RequirementDto.java
@@ -1,0 +1,10 @@
+package ph.edu.cspb.registrar.dto;
+
+import java.time.LocalDate;
+
+public record RequirementDto(
+        Short requirementTypeId,
+        boolean submitted,
+        LocalDate submittedDate
+) {
+}

--- a/src/main/java/ph/edu/cspb/registrar/dto/RequirementTypeDto.java
+++ b/src/main/java/ph/edu/cspb/registrar/dto/RequirementTypeDto.java
@@ -1,0 +1,7 @@
+package ph.edu.cspb.registrar.dto;
+
+public record RequirementTypeDto(
+        Short id,
+        String name
+) {
+}

--- a/src/main/java/ph/edu/cspb/registrar/dto/StudentDto.java
+++ b/src/main/java/ph/edu/cspb/registrar/dto/StudentDto.java
@@ -1,0 +1,24 @@
+package ph.edu.cspb.registrar.dto;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+public record StudentDto(
+        Long id,
+        String lrn,
+        String lastName,
+        String firstName,
+        String middleName,
+        String extensionName,
+        LocalDate birthDate,
+        String birthPlace,
+        String gender,
+        String nationality,
+        String religion,
+        Short numSiblings,
+        String siblingNames,
+        String imgPath,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt
+) {
+}

--- a/src/main/java/ph/edu/cspb/registrar/mapper/AddressMapper.java
+++ b/src/main/java/ph/edu/cspb/registrar/mapper/AddressMapper.java
@@ -1,0 +1,11 @@
+package ph.edu.cspb.registrar.mapper;
+
+import ph.edu.cspb.registrar.dto.AddressDto;
+import ph.edu.cspb.registrar.model.Address;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface AddressMapper {
+    AddressDto toDto(Address address);
+    Address toEntity(AddressDto dto);
+}

--- a/src/main/java/ph/edu/cspb/registrar/mapper/RequirementMapper.java
+++ b/src/main/java/ph/edu/cspb/registrar/mapper/RequirementMapper.java
@@ -1,0 +1,17 @@
+package ph.edu.cspb.registrar.mapper;
+
+import ph.edu.cspb.registrar.dto.RequirementDto;
+import ph.edu.cspb.registrar.model.Requirement;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface RequirementMapper {
+    @Mapping(source = "requirementType.id", target = "requirementTypeId")
+    RequirementDto toDto(Requirement r);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "student", ignore = true)
+    @Mapping(target = "requirementType", ignore = true)
+    Requirement toEntity(RequirementDto dto);
+}

--- a/src/main/java/ph/edu/cspb/registrar/mapper/RequirementTypeMapper.java
+++ b/src/main/java/ph/edu/cspb/registrar/mapper/RequirementTypeMapper.java
@@ -1,0 +1,10 @@
+package ph.edu.cspb.registrar.mapper;
+
+import ph.edu.cspb.registrar.dto.RequirementTypeDto;
+import ph.edu.cspb.registrar.model.RequirementType;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface RequirementTypeMapper {
+    RequirementTypeDto toDto(RequirementType type);
+}

--- a/src/main/java/ph/edu/cspb/registrar/mapper/StudentMapper.java
+++ b/src/main/java/ph/edu/cspb/registrar/mapper/StudentMapper.java
@@ -1,0 +1,11 @@
+package ph.edu.cspb.registrar.mapper;
+
+import ph.edu.cspb.registrar.dto.StudentDto;
+import ph.edu.cspb.registrar.model.Student;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface StudentMapper {
+    StudentDto toDto(Student student);
+    Student toEntity(StudentDto dto);
+}

--- a/src/main/java/ph/edu/cspb/registrar/model/Address.java
+++ b/src/main/java/ph/edu/cspb/registrar/model/Address.java
@@ -1,0 +1,34 @@
+package ph.edu.cspb.registrar.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.time.OffsetDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "addresses", schema = "school")
+public class Address {
+    @Id
+    private Long studentId;
+
+    @OneToOne
+    @MapsId
+    @JoinColumn(name = "student_id")
+    private Student student;
+
+    @Column(name = "house_no")
+    private String houseNo;
+
+    @Column(name = "street_subd")
+    private String streetSubd;
+
+    @Column(name = "bgy_code", nullable = false)
+    private String bgyCode;
+
+    @Column(name = "created_at")
+    private OffsetDateTime createdAt;
+}

--- a/src/main/java/ph/edu/cspb/registrar/model/Requirement.java
+++ b/src/main/java/ph/edu/cspb/registrar/model/Requirement.java
@@ -1,0 +1,33 @@
+package ph.edu.cspb.registrar.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "requirements", schema = "school")
+public class Requirement {
+    @EmbeddedId
+    private RequirementId id;
+
+    @ManyToOne
+    @MapsId("studentId")
+    @JoinColumn(name = "student_id")
+    private Student student;
+
+    @ManyToOne
+    @MapsId("requirementTypeId")
+    @JoinColumn(name = "requirement_type")
+    private RequirementType requirementType;
+
+    private boolean submitted = false;
+
+    @Column(name = "submitted_date")
+    private LocalDate submittedDate;
+}

--- a/src/main/java/ph/edu/cspb/registrar/model/RequirementId.java
+++ b/src/main/java/ph/edu/cspb/registrar/model/RequirementId.java
@@ -1,0 +1,19 @@
+package ph.edu.cspb.registrar.model;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Embeddable
+public class RequirementId implements Serializable {
+    private Long studentId;
+    private Short requirementTypeId;
+}

--- a/src/main/java/ph/edu/cspb/registrar/model/RequirementType.java
+++ b/src/main/java/ph/edu/cspb/registrar/model/RequirementType.java
@@ -1,0 +1,19 @@
+package ph.edu.cspb.registrar.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "requirement_types", schema = "school")
+public class RequirementType {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Short id;
+
+    private String name;
+}

--- a/src/main/java/ph/edu/cspb/registrar/model/Student.java
+++ b/src/main/java/ph/edu/cspb/registrar/model/Student.java
@@ -1,0 +1,72 @@
+package ph.edu.cspb.registrar.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "students", schema = "school")
+public class Student {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Pattern(regexp = "^[0-9]{12}$")
+    private String lrn;
+
+    @Column(name = "last_name", nullable = false)
+    private String lastName;
+
+    @Column(name = "first_name", nullable = false)
+    private String firstName;
+
+    @Column(name = "middle_name")
+    private String middleName;
+
+    @Column(name = "extension_name")
+    private String extensionName;
+
+    @Past
+    @Column(name = "birth_date", nullable = false)
+    private LocalDate birthDate;
+
+    @Column(name = "birth_place")
+    private String birthPlace;
+
+    private String gender;
+
+    private String nationality = "Filipino";
+
+    private String religion;
+
+    @Column(name = "num_siblings")
+    private Short numSiblings;
+
+    @Column(name = "sibling_names")
+    private String siblingNames;
+
+    @Column(name = "img_path")
+    private String imgPath;
+
+    @Column(name = "created_at")
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private OffsetDateTime updatedAt;
+
+    @OneToOne(mappedBy = "student", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Address address;
+
+    @OneToMany(mappedBy = "student", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Requirement> requirements = new HashSet<>();
+}

--- a/src/main/java/ph/edu/cspb/registrar/repo/AddressRepository.java
+++ b/src/main/java/ph/edu/cspb/registrar/repo/AddressRepository.java
@@ -1,0 +1,7 @@
+package ph.edu.cspb.registrar.repo;
+
+import ph.edu.cspb.registrar.model.Address;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AddressRepository extends JpaRepository<Address, Long> {
+}

--- a/src/main/java/ph/edu/cspb/registrar/repo/RequirementRepository.java
+++ b/src/main/java/ph/edu/cspb/registrar/repo/RequirementRepository.java
@@ -1,0 +1,8 @@
+package ph.edu.cspb.registrar.repo;
+
+import ph.edu.cspb.registrar.model.Requirement;
+import ph.edu.cspb.registrar.model.RequirementId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RequirementRepository extends JpaRepository<Requirement, RequirementId> {
+}

--- a/src/main/java/ph/edu/cspb/registrar/repo/RequirementTypeRepository.java
+++ b/src/main/java/ph/edu/cspb/registrar/repo/RequirementTypeRepository.java
@@ -1,0 +1,7 @@
+package ph.edu.cspb.registrar.repo;
+
+import ph.edu.cspb.registrar.model.RequirementType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RequirementTypeRepository extends JpaRepository<RequirementType, Short> {
+}

--- a/src/main/java/ph/edu/cspb/registrar/repo/StudentRepository.java
+++ b/src/main/java/ph/edu/cspb/registrar/repo/StudentRepository.java
@@ -1,0 +1,10 @@
+package ph.edu.cspb.registrar.repo;
+
+import ph.edu.cspb.registrar.model.Student;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudentRepository extends JpaRepository<Student, Long> {
+    Page<Student> findByLastNameContainingIgnoreCase(String lastName, Pageable pageable);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=registrar
+spring.jpa.open-in-view=false

--- a/src/main/resources/db/migration/V1__core_mvp.sql
+++ b/src/main/resources/db/migration/V1__core_mvp.sql
@@ -1,0 +1,129 @@
+/*═══════════════════════════════════════════════════════════════════════════
+  SCHEMA  : school    — MVP: Student Data Entry
+  AUTHOR  : DBA Team
+  NOTES   : Run with psql -f V1__core_mvp.sql  (PostgreSQL ≥ 14)
+═══════════════════════════════════════════════════════════════════════════*/
+
+-------------------------------------------------------------------------------
+-- 0.  Bootstrap – schema & extensions
+-------------------------------------------------------------------------------
+CREATE SCHEMA IF NOT EXISTS school;
+SET search_path TO school, public;
+
+-- Case-insensitive text & trigram search
+CREATE EXTENSION IF NOT EXISTS citext;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-------------------------------------------------------------------------------
+-- 1.  Simple look-ups
+-------------------------------------------------------------------------------
+CREATE TABLE requirement_types (
+    id   SMALLSERIAL PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE
+);
+
+INSERT INTO requirement_types (name) VALUES
+  ('Form 137'),
+  ('Report Card'),
+  ('PSA'),
+  ('Good Moral'),
+  ('2x2 Picture'),
+  ('Baptismal');
+
+-------------------------------------------------------------------------------
+-- 2.  Philippine geographic reference (PSGC codes)
+--     Load data later via ETL or COPY FROM PROGRAM.
+-------------------------------------------------------------------------------
+CREATE TABLE provinces (
+    province_code TEXT PRIMARY KEY,
+    name          TEXT NOT NULL
+);
+
+CREATE TABLE cities (
+    city_code     TEXT PRIMARY KEY,
+    province_code TEXT NOT NULL REFERENCES provinces
+                  ON UPDATE CASCADE ON DELETE RESTRICT,
+    name          TEXT NOT NULL,
+    UNIQUE (province_code, name)
+);
+
+CREATE TABLE barangays (
+    bgy_code      TEXT PRIMARY KEY,
+    city_code     TEXT NOT NULL REFERENCES cities
+                  ON UPDATE CASCADE ON DELETE RESTRICT,
+    name          TEXT NOT NULL,
+    UNIQUE (city_code, name)
+);
+
+-------------------------------------------------------------------------------
+-- 3.  Core STUDENT table
+-------------------------------------------------------------------------------
+CREATE TABLE students (
+    id               BIGSERIAL PRIMARY KEY,
+    lrn              TEXT UNIQUE
+                       CHECK (lrn ~ '^[0-9]{12}$'),      -- 12-digit DepEd LRN
+    last_name        CITEXT NOT NULL,
+    first_name       CITEXT NOT NULL,
+    middle_name      CITEXT,
+    extension_name   CITEXT,
+    birth_date       DATE NOT NULL,
+    birth_place      TEXT,
+    gender           TEXT CHECK (gender IN ('M','F','X','Prefer_not_to_say')),
+    nationality      TEXT NOT NULL DEFAULT 'Filipino',
+    religion         TEXT,
+    num_siblings     SMALLINT CHECK (num_siblings >= 0),
+    sibling_names    TEXT,                               -- can refactor later
+    img_path         TEXT,                               -- 2×2 photo URL/path
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+--  Fast searches & fuzzy matches
+CREATE INDEX idx_students_last_name_btree  ON students (last_name);
+CREATE INDEX idx_students_last_name_trgm   ON students USING GIN (last_name gin_trgm_ops);
+
+--  Auto-maintain updated_at
+CREATE OR REPLACE FUNCTION trg_set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END $$;
+CREATE TRIGGER set_updated_at
+BEFORE UPDATE ON students
+FOR EACH ROW EXECUTE FUNCTION trg_set_updated_at();
+
+-------------------------------------------------------------------------------
+-- 4.  One current address per student (authoritative barangay FK only)
+-------------------------------------------------------------------------------
+CREATE TABLE addresses (
+    student_id  BIGINT PRIMARY KEY REFERENCES students
+                ON UPDATE CASCADE ON DELETE CASCADE,
+    house_no    TEXT,
+    street_subd TEXT,
+    bgy_code    TEXT NOT NULL REFERENCES barangays
+                ON UPDATE CASCADE ON DELETE RESTRICT,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+--  Geo look-ups: who lives in this barangay?
+CREATE INDEX idx_addresses_bgy ON addresses (bgy_code);
+
+-------------------------------------------------------------------------------
+-- 5.  Admission requirements fulfilled (M:N bridge)
+-------------------------------------------------------------------------------
+CREATE TABLE requirements (
+    student_id        BIGINT     NOT NULL REFERENCES students
+                      ON UPDATE CASCADE ON DELETE CASCADE,
+    requirement_type  SMALLINT   NOT NULL REFERENCES requirement_types
+                      ON UPDATE CASCADE ON DELETE RESTRICT,
+    submitted         BOOLEAN    NOT NULL DEFAULT FALSE,
+    submitted_date    DATE,
+    PRIMARY KEY (student_id, requirement_type),
+    CHECK (submitted OR submitted_date IS NULL)   -- no date without TRUE flag
+);
+
+--  Quick “who still owes X?” list
+CREATE INDEX idx_requirements_missing
+  ON requirements (requirement_type)
+  WHERE submitted = FALSE;

--- a/src/test/java/ph/edu/cspb/registrar/StudentControllerIT.java
+++ b/src/test/java/ph/edu/cspb/registrar/StudentControllerIT.java
@@ -1,0 +1,56 @@
+package ph.edu.cspb.registrar;
+
+import ph.edu.cspb.registrar.dto.StudentDto;
+import ph.edu.cspb.registrar.repo.StudentRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+class StudentControllerIT {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    TestRestTemplate restTemplate;
+    @Autowired
+    StudentRepository studentRepository;
+
+    @Test
+    void studentCrudHappyPath() {
+        StudentDto dto = new StudentDto(null, "123456789012", "Doe", "John", null, null,
+                LocalDate.of(2000,1,1), null, null, "Filipino", null,
+                (short)0, null, null, null, null);
+        StudentDto created = restTemplate.postForObject("http://localhost:"+port+"/api/students", dto, StudentDto.class);
+        assertThat(created.id()).isNotNull();
+
+        StudentDto fetched = restTemplate.getForObject("http://localhost:"+port+"/api/students/"+created.id(), StudentDto.class);
+        assertThat(fetched.lrn()).isEqualTo("123456789012");
+
+        restTemplate.delete("http://localhost:"+port+"/api/students/"+created.id());
+        assertThat(studentRepository.existsById(created.id())).isFalse();
+    }
+}

--- a/src/test/java/ph/edu/cspb/registrar/StudentValidationTest.java
+++ b/src/test/java/ph/edu/cspb/registrar/StudentValidationTest.java
@@ -1,0 +1,49 @@
+package ph.edu.cspb.registrar;
+
+import ph.edu.cspb.registrar.dto.StudentDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+class StudentValidationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    TestRestTemplate restTemplate;
+
+    @Test
+    void invalidLrnReturnsBadRequest() {
+        StudentDto dto = new StudentDto(null, "BADLRN", "Doe", "John", null, null,
+                LocalDate.of(2000,1,1), null, null, "Filipino", null,
+                (short)0, null, null, null, null);
+        ResponseEntity<String> response = restTemplate.postForEntity("http://localhost:"+port+"/api/students", dto, String.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+}


### PR DESCRIPTION
## Summary
- set up Maven build for Java 21
- add Flyway baseline migration
- implement domain entities, repositories, DTOs and mappers
- build REST API for students and requirements
- provide integration and validation tests using Testcontainers
- remove unused Maven build file and update Gradle dependencies
- use `ph.edu.cspb.registrar` as the application root package

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685f3c97b2bc8322973f8c7a59d46202