### PR TITLE
Add Dockerfile and build instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# Build stage
+FROM gradle:8.14.2-jdk21-alpine AS builder
+WORKDIR /workspace/app
+COPY . .
+RUN gradle clean build -x test
+
+# Runtime stage
+FROM openjdk:21-jdk-alpine3.21
+WORKDIR /app
+COPY --from=builder /workspace/app/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/README.md
+++ b/README.md
@@ -56,3 +56,14 @@ The tests use Mockito to mock the data layer so Docker is not required.
 
 Test reports can be found under `build/reports/tests/test` after execution.
 
+
+## Docker Image
+
+This project provides a multi-stage Dockerfile. Build the image and push it under `jasoncalalang/cspb-api:1.0` using:
+
+```bash
+docker build -t jasoncalalang/cspb-api:1.0 .
+docker push jasoncalalang/cspb-api:1.0
+```
+
+The build stage uses `gradle:8.14.2-jdk21-alpine` while the runtime stage uses `openjdk:21-jdk-alpine3.21`.


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile using gradle builder and alpine runtime with Java 21
- document docker image build and push steps in README

## Testing
- `./gradlew test`
