### PR TITLE
Add simple landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ See `docs/swagger.yaml` for detailed request and response structures.
     ```
 
     The API will be available at `http://localhost:8080`.
+    Visiting the root path (`/`) displays a simple landing page with a link to
+    the Swagger UI (`/swagger-ui.html`).
 
 ## Running Tests
 

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Registrar API</title>
+</head>
+<body>
+    <h1>Registrar API</h1>
+    <p>This service provides a REST API for managing students.</p>
+    <p>Visit <a href="/swagger-ui.html">/swagger-ui.html</a> for documentation.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` so `/` doesn't return a 404
- note the landing page in the README

## Testing
- `./gradlew test`

