### PR TITLE
Add health check endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This project is a Spring Boot application providing a simple registrar API. The 
 | GET    | `/api/students/{id}/requirements`     | Get requirements for a student |
 | PUT    | `/api/students/{id}/requirements/{typeId}` | Set/update a requirement |
 | PATCH  | `/api/students/{id}/requirements`     | Batch update requirements |
+| GET    | `/health` or `/api/health`            | Health check              |
 
 See `docs/swagger.yaml` for detailed request and response structures.
 

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -256,6 +256,26 @@ paths:
           description: No content
         '404':
           description: Not found
+  /health:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Health'
+  /api/health:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Health'
 components:
   schemas:
     Student:
@@ -350,4 +370,9 @@ components:
         name:
           type: string
           description: Requirement name
+    Health:
+      type: object
+      properties:
+        message:
+          type: string
 

--- a/src/main/java/ph/edu/cspb/registrar/api/HealthController.java
+++ b/src/main/java/ph/edu/cspb/registrar/api/HealthController.java
@@ -1,0 +1,16 @@
+package ph.edu.cspb.registrar.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+public class HealthController {
+
+    @GetMapping({"/health", "/api/health"})
+    public ResponseEntity<Map<String, String>> health() {
+        return ResponseEntity.ok(Map.of("message", "successful"));
+    }
+}

--- a/src/test/java/ph/edu/cspb/registrar/HealthControllerTest.java
+++ b/src/test/java/ph/edu/cspb/registrar/HealthControllerTest.java
@@ -1,0 +1,29 @@
+package ph.edu.cspb.registrar;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import ph.edu.cspb.registrar.api.HealthController;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HealthControllerTest {
+
+    private HealthController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new HealthController();
+    }
+
+    @Test
+    void healthReturnsSuccessfulMessage() {
+        ResponseEntity<Map<String, String>> response = controller.health();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).containsEntry("message", "successful");
+    }
+}


### PR DESCRIPTION
## Summary
- add `HealthController` with `/health` and `/api/health` routes
- document the new endpoint in README and OpenAPI spec
- cover the controller with unit tests

## Testing
- `./gradlew test --no-daemon`
