### PR TITLE
Add Helm chart and deploy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,23 @@ jobs:
           context: .
           push: true
           tags: jasoncalalang/cspb-registrar-api:1.0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+
+      - name: Deploy to Kubernetes
+        env:
+          INGRESS_HOST: ${{ secrets.INGRESS_HOST }}
+          TLS_HOST: ${{ secrets.TLS_HOST }}
+          TLS_SECRET: ${{ secrets.TLS_SECRET }}
+          DATASOURCE_URL: ${{ vars.DATASOURCE_URL }}
+          DATASOURCE_USERNAME: ${{ secrets.DATASOURCE_USERNAME }}
+          DATASOURCE_PASSWORD: ${{ secrets.DATASOURCE_PASSWORD }}
+        run: |
+          helm upgrade --install registrar ./kube \
+            --set ingress.host=$INGRESS_HOST \
+            --set ingress.tls.hosts[0]=$TLS_HOST \
+            --set ingress.tls.secretName=$TLS_SECRET \
+            --set spring.datasource.url=$DATASOURCE_URL \
+            --set spring.datasource.username=$DATASOURCE_USERNAME \
+            --set spring.datasource.password=$DATASOURCE_PASSWORD

--- a/kube/Chart.yaml
+++ b/kube/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: registrar-api
+version: 0.1.0
+appVersion: "1.0"
+description: Helm chart for CSPB Registrar API

--- a/kube/templates/_helpers.tpl
+++ b/kube/templates/_helpers.tpl
@@ -1,0 +1,12 @@
+{{- define "registrar-api.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "registrar-api.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "registrar-api.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}

--- a/kube/templates/deployment.yaml
+++ b/kube/templates/deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "registrar-api.fullname" . }}
+  labels:
+    app: {{ include "registrar-api.name" . }}
+    chart: {{ include "registrar-api.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "registrar-api.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "registrar-api.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ include "registrar-api.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.targetPort }}
+          env:
+            - name: SPRING_DATASOURCE_URL
+              value: {{ .Values.spring.datasource.url | quote }}
+            - name: SPRING_DATASOURCE_USERNAME
+              value: {{ .Values.spring.datasource.username | quote }}
+            - name: SPRING_DATASOURCE_PASSWORD
+              value: {{ .Values.spring.datasource.password | quote }}
+          volumeMounts:
+            - name: pgsql-root
+              mountPath: /app/root.pem
+              subPath: root.pem
+      volumes:
+        - name: pgsql-root
+          secret:
+            secretName: pgsql-root
+            items:
+              - key: root.pem
+                path: root.pem

--- a/kube/templates/ingress.yaml
+++ b/kube/templates/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "registrar-api.fullname" . }}
+  annotations:
+{{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+{{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className | default "nginx" }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "registrar-api.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        {{- range .Values.ingress.tls.hosts }}
+        - {{ . }}
+        {{- end }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+{{- end }}
+{{- end }}

--- a/kube/templates/service.yaml
+++ b/kube/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "registrar-api.fullname" . }}
+  labels:
+    app: {{ include "registrar-api.name" . }}
+    release: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ include "registrar-api.name" . }}
+    release: {{ .Release.Name }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http

--- a/kube/values.yaml
+++ b/kube/values.yaml
@@ -1,0 +1,23 @@
+replicaCount: 1
+image:
+  repository: jasoncalalang/cspb-registrar-api
+  tag: "1.0"
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8080
+ingress:
+  enabled: true
+  annotations: {}
+  host: example.com
+  tls:
+    enabled: true
+    hosts:
+      - example.com
+    secretName: tls-secret
+spring:
+  datasource:
+    url: ""
+    username: ""
+    password: ""


### PR DESCRIPTION
## Summary
- add Helm chart for the registrar API
- include Deployment, Service and Ingress templates
- configure GitHub Actions to deploy the chart with host variables
- parameterize datasource settings in workflow
- mount the `pgsql-root` secret so the app can verify the database TLS certificate

## Testing
- `./gradlew test`


