### PR TITLE
Add parent guardian table and API endpoints

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -234,6 +234,49 @@ paths:
           description: No content
         '404':
           description: Not found
+  /api/students/{id}/parents:
+    get:
+      summary: Get parents or guardians for a student
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ParentGuardian'
+        '404':
+          description: Not found
+    patch:
+      summary: Batch update parents or guardians
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/ParentGuardian'
+      responses:
+        '204':
+          description: No content
+        '404':
+          description: Not found
   /api/students/{id}/requirements/{typeId}:
     put:
       summary: Set/update a requirement
@@ -399,6 +442,41 @@ components:
           type: string
           description: Requirement name
           example: "Birth Certificate"
+    ParentGuardian:
+      type: object
+      properties:
+        role:
+          type: string
+          description: Relationship to the student
+          example: father
+        firstName:
+          type: string
+          description: First name
+          example: John
+        lastName:
+          type: string
+          description: Last name
+          example: Doe
+        middleName:
+          type: string
+          description: Middle name
+          example: Q
+        occupation:
+          type: string
+          description: Occupation
+          example: Engineer
+        contactNum:
+          type: string
+          description: Contact number
+          example: '09171234567'
+        email:
+          type: string
+          description: Email address
+          example: father@example.com
+        highestEducationalAttainment:
+          type: string
+          description: Highest educational attainment
+          example: College
     Health:
       type: object
       properties:

--- a/sql/V2__parent_guardian.sql
+++ b/sql/V2__parent_guardian.sql
@@ -1,0 +1,26 @@
+/*═══════════════════════════════════════════════════════════════════════════
+  SCHEMA  : school    — Parent/Guardian Table
+  AUTHOR  : DBA Team
+  NOTES   : Run with psql -f V2__parent_guardian.sql  (PostgreSQL ≥ 14)
+═══════════════════════════════════════════════════════════════════════════*/
+
+SET search_path TO school, public;
+
+CREATE TABLE parent_guardians (
+    id        BIGSERIAL PRIMARY KEY,
+    student_id BIGINT NOT NULL REFERENCES students
+                ON UPDATE CASCADE ON DELETE CASCADE,
+    role       TEXT NOT NULL CHECK (role IN ('father','mother','guardian')),
+    last_name  CITEXT NOT NULL,
+    first_name CITEXT NOT NULL,
+    middle_name CITEXT,
+    occupation TEXT,
+    contact_num TEXT,
+    email      TEXT,
+    highest_educational_attainment TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (student_id, role)
+);
+
+-- quick lookup by student
+CREATE INDEX idx_parent_guardians_student ON parent_guardians (student_id);

--- a/src/main/java/ph/edu/cspb/registrar/dto/ParentGuardianDto.java
+++ b/src/main/java/ph/edu/cspb/registrar/dto/ParentGuardianDto.java
@@ -1,0 +1,13 @@
+package ph.edu.cspb.registrar.dto;
+
+public record ParentGuardianDto(
+        String role,
+        String firstName,
+        String lastName,
+        String middleName,
+        String occupation,
+        String contactNum,
+        String email,
+        String highestEducationalAttainment
+) {
+}

--- a/src/main/java/ph/edu/cspb/registrar/mapper/ParentGuardianMapper.java
+++ b/src/main/java/ph/edu/cspb/registrar/mapper/ParentGuardianMapper.java
@@ -1,0 +1,16 @@
+package ph.edu.cspb.registrar.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import ph.edu.cspb.registrar.dto.ParentGuardianDto;
+import ph.edu.cspb.registrar.model.ParentGuardian;
+
+@Mapper(componentModel = "spring")
+public interface ParentGuardianMapper {
+    ParentGuardianDto toDto(ParentGuardian entity);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "student", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    ParentGuardian toEntity(ParentGuardianDto dto);
+}

--- a/src/main/java/ph/edu/cspb/registrar/mapper/StudentMapper.java
+++ b/src/main/java/ph/edu/cspb/registrar/mapper/StudentMapper.java
@@ -11,6 +11,7 @@ public interface StudentMapper {
 
     @Mapping(target = "address", ignore = true)
     @Mapping(target = "requirements", ignore = true)
+    @Mapping(target = "parents", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
     Student toEntity(StudentDto dto);

--- a/src/main/java/ph/edu/cspb/registrar/model/ParentGuardian.java
+++ b/src/main/java/ph/edu/cspb/registrar/model/ParentGuardian.java
@@ -1,0 +1,54 @@
+package ph.edu.cspb.registrar.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "parent_guardians", schema = "school",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"student_id", "role"}))
+public class ParentGuardian {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "student_id", nullable = false)
+    private Student student;
+
+    @Column(nullable = false)
+    private String role;
+
+    @Column(name = "first_name", nullable = false)
+    private String firstName;
+
+    @Column(name = "last_name", nullable = false)
+    private String lastName;
+
+    @Column(name = "middle_name")
+    private String middleName;
+
+    private String occupation;
+
+    @Column(name = "contact_num")
+    private String contactNum;
+
+    private String email;
+
+    @Column(name = "highest_educational_attainment")
+    private String highestEducationalAttainment;
+
+    @Column(name = "created_at")
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        createdAt = OffsetDateTime.now();
+    }
+}

--- a/src/main/java/ph/edu/cspb/registrar/model/Student.java
+++ b/src/main/java/ph/edu/cspb/registrar/model/Student.java
@@ -11,6 +11,7 @@ import java.time.OffsetDateTime;
 import java.util.HashSet;
 import java.util.Set;
 
+
 @Getter
 @Setter
 @NoArgsConstructor
@@ -69,6 +70,9 @@ public class Student {
 
     @OneToMany(mappedBy = "student", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<Requirement> requirements = new HashSet<>();
+
+    @OneToMany(mappedBy = "student", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<ParentGuardian> parents = new HashSet<>();
 
     @PrePersist
     public void prePersist() {

--- a/src/main/java/ph/edu/cspb/registrar/repo/ParentGuardianRepository.java
+++ b/src/main/java/ph/edu/cspb/registrar/repo/ParentGuardianRepository.java
@@ -1,0 +1,12 @@
+package ph.edu.cspb.registrar.repo;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import ph.edu.cspb.registrar.model.ParentGuardian;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ParentGuardianRepository extends JpaRepository<ParentGuardian, Long> {
+    List<ParentGuardian> findByStudentId(Long studentId);
+    Optional<ParentGuardian> findByStudentIdAndRole(Long studentId, String role);
+}

--- a/src/test/java/ph/edu/cspb/registrar/StudentControllerTest.java
+++ b/src/test/java/ph/edu/cspb/registrar/StudentControllerTest.java
@@ -26,10 +26,12 @@ class StudentControllerTest {
     private AddressRepository addressRepository;
     private RequirementTypeRepository requirementTypeRepository;
     private RequirementRepository requirementRepository;
+    private ParentGuardianRepository parentGuardianRepository;
     private StudentMapper studentMapper;
     private AddressMapper addressMapper;
     private RequirementTypeMapper requirementTypeMapper;
     private RequirementMapper requirementMapper;
+    private ParentGuardianMapper parentGuardianMapper;
     private StudentController controller;
 
     @BeforeEach
@@ -38,19 +40,23 @@ class StudentControllerTest {
         addressRepository = mock(AddressRepository.class);
         requirementTypeRepository = mock(RequirementTypeRepository.class);
         requirementRepository = mock(RequirementRepository.class);
+        parentGuardianRepository = mock(ParentGuardianRepository.class);
         studentMapper = Mappers.getMapper(StudentMapper.class);
         addressMapper = Mappers.getMapper(AddressMapper.class);
         requirementTypeMapper = Mappers.getMapper(RequirementTypeMapper.class);
         requirementMapper = Mappers.getMapper(RequirementMapper.class);
+        parentGuardianMapper = Mappers.getMapper(ParentGuardianMapper.class);
         controller = new StudentController(
                 studentRepository,
                 addressRepository,
                 requirementTypeRepository,
                 requirementRepository,
+                parentGuardianRepository,
                 studentMapper,
                 addressMapper,
                 requirementTypeMapper,
-                requirementMapper);
+                requirementMapper,
+                parentGuardianMapper);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add migration for `parent_guardians` table
- include parent guardian model/repo/dto/mapper
- expose endpoints to manage a student's parents or guardians
- document new endpoints in Swagger

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6865f277680083228a6eb2b0eeaf8631