### PR TITLE
Update student creation

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -31,7 +31,7 @@ paths:
               type: array
               minItems: 1
               items:
-                $ref: '#/components/schemas/Student'
+                $ref: '#/components/schemas/StudentCreate'
       responses:
         '200':
           description: Created
@@ -398,6 +398,47 @@ components:
           format: date-time
           description: Time record was last updated
           example: "2024-01-02T12:00:00Z"
+    StudentCreate:
+      type: object
+      properties:
+        lrn:
+          type: string
+        lastName:
+          type: string
+        firstName:
+          type: string
+        middleName:
+          type: string
+        extensionName:
+          type: string
+        birthDate:
+          type: string
+          format: date
+        birthPlace:
+          type: string
+        gender:
+          type: string
+        nationality:
+          type: string
+        religion:
+          type: string
+        numSiblings:
+          type: integer
+          format: int32
+        siblingNames:
+          type: string
+        imgPath:
+          type: string
+        address:
+          $ref: '#/components/schemas/Address'
+        requirements:
+          type: array
+          items:
+            $ref: '#/components/schemas/Requirement'
+        parents:
+          type: array
+          items:
+            $ref: '#/components/schemas/ParentGuardian'
     Address:
       type: object
       properties:

--- a/src/main/java/ph/edu/cspb/registrar/dto/StudentCreateDto.java
+++ b/src/main/java/ph/edu/cspb/registrar/dto/StudentCreateDto.java
@@ -1,0 +1,23 @@
+package ph.edu.cspb.registrar.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record StudentCreateDto(
+        String lrn,
+        String lastName,
+        String firstName,
+        String middleName,
+        String extensionName,
+        LocalDate birthDate,
+        String birthPlace,
+        String gender,
+        String nationality,
+        String religion,
+        Short numSiblings,
+        String siblingNames,
+        String imgPath,
+        AddressDto address,
+        List<RequirementDto> requirements,
+        List<ParentGuardianDto> parents
+) {}

--- a/src/test/java/ph/edu/cspb/registrar/StudentControllerTest.java
+++ b/src/test/java/ph/edu/cspb/registrar/StudentControllerTest.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import ph.edu.cspb.registrar.api.StudentController;
 import ph.edu.cspb.registrar.dto.StudentDto;
+import ph.edu.cspb.registrar.dto.StudentCreateDto;
 import ph.edu.cspb.registrar.mapper.*;
 import ph.edu.cspb.registrar.model.Student;
 import ph.edu.cspb.registrar.repo.*;
@@ -67,9 +68,24 @@ class StudentControllerTest {
             return s;
         });
 
-        StudentDto dto = new StudentDto(null, "123456789012", "Doe", "John", null, null,
-                LocalDate.of(2000,1,1), null, null, "Filipino", null,
-                (short)0, null, null, null, null);
+        StudentCreateDto dto = new StudentCreateDto(
+                "123456789012",
+                "Doe",
+                "John",
+                null,
+                null,
+                LocalDate.of(2000,1,1),
+                null,
+                null,
+                "Filipino",
+                null,
+                (short)0,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
 
         ResponseEntity<List<StudentDto>> response = controller.createStudents(List.of(dto));
 


### PR DESCRIPTION
## Summary
- extend `/students` creation API to accept address, parent and requirement info
- add `StudentCreateDto`
- update tests and OpenAPI spec

## Testing
- `./gradlew test --rerun-tasks`

------
https://chatgpt.com/codex/tasks/task_e_686681fd83a483229194d4c9936823ec